### PR TITLE
Remove SSL from database settings

### DIFF
--- a/sharespots/settings.py
+++ b/sharespots/settings.py
@@ -124,4 +124,4 @@ STATICFILES_DIRS = (
 )
 
 # Activate Django-Heroku.
-django_heroku.settings(locals())
+django_heroku.settings(locals(), logging=not DEBUG, databases=not DEBUG)


### PR DESCRIPTION
Fixing an error message "server does not support SSL, but SSL was required" by updating settings.py 