### PR TITLE
fix: Load all fonts over https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ env.py
 # End of https://www.gitignore.io/api/python,django
 frontend/src/styles/.sass-cache
 frontend/node_modules/
+frontend/.sass-cache
 
 
 #Pycharm

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
         {% block layout %} {% endblock %}
 
         <script src="{% static 'main.js' %}" type="module"></script>
-        <link href='http://fonts.googleapis.com/css?family=Monoton|Roboto' rel='stylesheet' type='text/css'>
-        <link href="https://fonts.googleapis.com/css?family=Raleway:300,700" rel="stylesheet">
+        <link href='https://fonts.googleapis.com/css?family=Monoton|Roboto' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Raleway:300,700' rel='stylesheet' type='text/css'>
     </body>
 </html>


### PR DESCRIPTION
### What change does this PR introduce?

Use https for loading fonts as otherwise `heroku` doesn't load the font